### PR TITLE
Bump deprecated artifact actions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,14 +90,14 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Upload bin
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bin
           path: bin
       - name: Tar provider bin
         run: tar -zcf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace }}/bin/ .
       - name: Upload provider bin
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nodejs-dynamic-provider.tar.gz
           path: ${{ github.workspace }}/provider.tar.gz
@@ -144,7 +144,7 @@ jobs:
           node-version: ${{matrix.nodeversion}}
           registry-url: https://registry.npmjs.org
       - name: Download bin
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bin
           path: bin
@@ -157,7 +157,7 @@ jobs:
       - name: Compress SDK folder
         run: tar -zcf sdk.tar.gz -C sdk .
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sdk.tar.gz
           path: ${{ github.workspace}}/sdk.tar.gz
@@ -204,7 +204,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Download provider binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: nodejs-dynamic-provider.tar.gz
           path: ${{ github.workspace }}/bin
@@ -249,7 +249,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           node-version: ${{matrix.nodeversion}}
       - name: Download SDK
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: sdk.tar.gz
           path: ${{ github.workspace}}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -82,14 +82,14 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Upload bin
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bin
           path: bin
       - name: Tar provider bin
         run: tar -zcf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace }}/bin/ .
       - name: Upload provider bin
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nodejs-dynamic-provider.tar.gz
           path: ${{ github.workspace }}/provider.tar.gz
@@ -136,7 +136,7 @@ jobs:
           node-version: ${{matrix.nodeversion}}
           registry-url: https://registry.npmjs.org
       - name: Download bin
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bin
           path: bin
@@ -149,7 +149,7 @@ jobs:
       - name: Compress SDK folder
         run: tar -zcf sdk.tar.gz -C sdk .
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sdk.tar.gz
           path: ${{ github.workspace}}/sdk.tar.gz
@@ -196,7 +196,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Download provider binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: nodejs-dynamic-provider.tar.gz
           path: ${{ github.workspace }}/bin
@@ -249,7 +249,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           node-version: ${{matrix.nodeversion}}
       - name: Download SDK
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: sdk.tar.gz
           path: ${{ github.workspace}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,14 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Upload bin
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bin
           path: bin
       - name: Tar provider bin
         run: tar -zcf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace }}/${{ env.PROVIDER }}/bin/ .
       - name: Upload provider bin
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/provider.tar.gz
@@ -138,7 +138,7 @@ jobs:
           node-version: ${{matrix.nodeversion}}
           registry-url: https://registry.npmjs.org
       - name: Download bin
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bin
           path: bin
@@ -152,7 +152,7 @@ jobs:
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
@@ -191,7 +191,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Download provider binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
@@ -251,21 +251,21 @@ jobs:
         with:
           python-version: ${{matrix.pythonversion}}
       - name: Download python SDK
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: python-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/
       - name: Uncompress python SDK
         run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
       - name: Download dotnet SDK
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dotnet-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/
       - name: Uncompress dotnet SDK
         run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
       - name: Download nodejs SDK
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: nodejs-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build dist packages
         run: make dist
       - name: Upload dist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -109,14 +109,14 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Upload bin
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bin
           path: bin
       - name: Tar provider bin
         run: tar -zcf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace }}/${{ env.PROVIDER }}/bin/ .
       - name: Upload provider bin
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/provider.tar.gz
@@ -164,7 +164,7 @@ jobs:
           node-version: ${{matrix.nodeversion}}
           registry-url: https://registry.npmjs.org
       - name: Download bin
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bin
           path: bin
@@ -178,7 +178,7 @@ jobs:
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz


### PR DESCRIPTION
GitHub deprecated `actions/upload-artifact@v1/v2/v3` and `actions/download-artifact@v1/v2/v3` in late 2024. Workflows fail CI as a result.

These changes bump every artifact action reference across all four workflow files (`run-acceptance-tests.yml`, `release.yml`, `pre-release.yml`, `main.yml`) to v4. All upload names are unique within their workflow run (matrix dimensions are single-element, and matrix-templated names are inherently unique across matrix legs), so the v4 name-uniqueness constraint is satisfied.

This unblocks #8.
